### PR TITLE
Rename Cargo package to tre-command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "tre"
+name = "tre-command"
 version = "0.2.2"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tre"
+name = "tre-command"
 version = "0.2.2"
 authors = ["Daniel Duan <daniel@duan.ca>"]
 edition = "2018"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+.PHONY: build
+build:
+	@cargo build --release
+	@mv target/release/tre-command target/release-tre
+
 .PHONY: check
 check:
 	@cargo check

--- a/ci/before_deploy.ps1
+++ b/ci/before_deploy.ps1
@@ -10,7 +10,7 @@ Set-Location $STAGE
 
 $ZIP = "$SRC_DIR\$($Env:CRATE_NAME)-$($Env:APPVEYOR_REPO_TAG_NAME)-$($Env:TARGET).zip"
 
-Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\tre.exe" '.\'
+Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\tre-command.exe" '.\tre.exe'
 
 7z a "$ZIP" *
 

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -17,9 +17,9 @@ main() {
 
     test -f Cargo.lock || cargo generate-lockfile
 
-    cross rustc --bin tre --target $TARGET --release -- -C lto
+    cross rustc --bin tre-command --target $TARGET --release -- -C lto
 
-    cp target/$TARGET/release/tre $stage/
+    cp target/$TARGET/release/tre-command $stage/tre
 
     cd $stage
     tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *


### PR DESCRIPTION
`tre` is generally unavailable in most package registries. Since we
already exist in Nix as `tre-command`, might as well make it official.