### PR TITLE
Add option to collapse directories with single entries

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,6 +63,9 @@ pub struct Interface {
     pub portable: bool,
     #[clap(default_value = ".")]
     pub path: String,
+    /// Collapse directories single entries.
+    #[clap(long, parse(from_flag))]
+    pub collapse: bool,
 }
 
 #[cfg(test)]

--- a/src/diagram_formatting.rs
+++ b/src/diagram_formatting.rs
@@ -63,17 +63,10 @@ fn format_file(
     collapse: bool,
 ) {
     let mut current = file;
+    let mut path = current.path.clone();
+    let mut name = current.display_name.clone();
 
     let prefix = make_prefix(tree, current, format_history);
-    let mut path = if make_absolute {
-        fs::canonicalize(&current.path)
-            .unwrap()
-            .display()
-            .to_string()
-    } else {
-        current.path.clone()
-    };
-    let mut name = current.display_name.clone();
 
     if collapse {
         while current.children_count() == 1 {
@@ -84,6 +77,10 @@ fn format_file(
             path = child_node.path.clone();
             current = child_node;
         }
+    }
+
+    if make_absolute {
+        path = fs::canonicalize(&path).unwrap().display().to_string();
     }
 
     result.push(FormattedEntry {

--- a/src/tre.rs
+++ b/src/tre.rs
@@ -26,6 +26,7 @@ pub struct RunOptions {
     pub exclude_patterns: Vec<Regex>,
     pub coloring: cli::Coloring,
     pub portable_aliases: bool,
+    pub collapse: bool,
 }
 
 #[cfg(not(windows))]
@@ -65,6 +66,7 @@ impl From<cli::Interface> for RunOptions {
                 .collect(),
             coloring: inputs.color,
             portable_aliases: inputs.portable,
+            collapse: inputs.collapse,
         }
     }
 }
@@ -99,8 +101,12 @@ pub fn run(option: RunOptions) {
     if option.output_json {
         println!("{}", json_formatting::format_paths(&option.root, paths));
     } else {
-        let format_result =
-            diagram_formatting::format_paths(&option.root, paths, option.portable_aliases);
+        let format_result = diagram_formatting::format_paths(
+            &option.root,
+            paths,
+            option.portable_aliases,
+            option.collapse,
+        );
         let lscolors = LsColors::from_env().unwrap_or_default();
         let coloring = match option.coloring {
             cli::Coloring::Never => None,


### PR DESCRIPTION
Hello! I'd like to collapse directories with single entries. Here is a possible implementation, that extends the default formatter.

Coloring on this could be improved, to highlight the base of files with collapsed directories.
