### PR TITLE
add an 'include' option as an inverted exclude

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,9 @@ pub struct Interface {
     /// Limit depth of the tree in output.
     #[clap(long, short)]
     pub limit: Option<usize>,
+    /// Include paths matching a regex pattern. Repeatable.
+    #[clap(long, short = 'I', value_name = "PATTERN")]
+    pub include: Vec<String>,
     /// Exclude paths matching a regex pattern. Repeatable.
     #[clap(long, short = 'E', value_name = "PATTERN")]
     pub exclude: Vec<String>,


### PR DESCRIPTION
I felt like this was missing and it was the reason why I searched for a tool like this in the first place. (I wanted to only show files with a certain extension)
I have never really used rust but I felt confident enough to do this, if I made an obvious mistake please tell me.
Also feel free to change the name of the option, it's just the first that came into my mind.