### PR TITLE
Fix completion for file path arguments on macOS

### DIFF
--- a/scripts/completion/_tre
+++ b/scripts/completion/_tre
@@ -37,7 +37,7 @@ _tre() {
 '--json[Output JSON instead of tree diagram]' \
 '-p[Generate portable (absolute) paths for editor aliases. By default, aliases use relative paths for better performance]' \
 '--portable[Generate portable (absolute) paths for editor aliases. By default, aliases use relative paths for better performance]' \
-'::path:' \
+'1: :_files' \
 && ret=0
 }
 


### PR DESCRIPTION
Replace `::path:` with explicit `_files` completion to ensure reliable file name completion in zsh.

Without this change file name completion doesn't seem to work on macOS (Sequoia).